### PR TITLE
Add basic React frontend with Express server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+front/node_modules/

--- a/front/README.md
+++ b/front/README.md
@@ -15,5 +15,11 @@ It provides login and register forms that interact with the deployed backend.
    ```
 3. Open `http://localhost:3000` in your browser.
 
-The frontend expects the backend to be accessible at
+By default the frontend expects the backend to be accessible at
 `https://proyectodevopsbackend-evcnbwdbcrdyc0d8.canadacentral-01.azurewebsites.net`.
+You can change this by setting the environment variable `API_BASE` before starting
+the server:
+
+```bash
+API_BASE="https://your-backend-url" npm start
+```

--- a/front/README.md
+++ b/front/README.md
@@ -1,0 +1,19 @@
+# TuristAPP Front
+
+This directory contains a minimal React application served with Express.
+It provides login and register forms that interact with the deployed backend.
+
+## Running locally
+
+1. Install dependencies (requires Node.js):
+   ```bash
+   npm install
+   ```
+2. Start the server:
+   ```bash
+   npm start
+   ```
+3. Open `http://localhost:3000` in your browser.
+
+The frontend expects the backend to be accessible at
+`https://proyectodevopsbackend-evcnbwdbcrdyc0d8.canadacentral-01.azurewebsites.net`.

--- a/front/package.json
+++ b/front/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "front",
+  "version": "1.0.0",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/front/public/app.js
+++ b/front/public/app.js
@@ -1,0 +1,94 @@
+const API_BASE = 'https://proyectodevopsbackend-evcnbwdbcrdyc0d8.canadacentral-01.azurewebsites.net';
+
+function App() {
+  const [view, setView] = React.useState('login');
+  const [token, setToken] = React.useState(null);
+
+  const handleLogin = async (e) => {
+    e.preventDefault();
+    const form = e.target;
+    const email = form.email.value;
+    const password = form.password.value;
+    try {
+      const res = await fetch(`${API_BASE}/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password })
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setToken(data.token || '');
+        setView('index');
+      } else {
+        alert('Login failed');
+      }
+    } catch (err) {
+      console.error(err);
+      alert('Error connecting to server');
+    }
+  };
+
+  const handleRegister = async (e) => {
+    e.preventDefault();
+    const form = e.target;
+    const email = form.email.value;
+    const password = form.password.value;
+    try {
+      const res = await fetch(`${API_BASE}/register`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password })
+      });
+      if (res.ok) {
+        alert('Registration successful');
+        setView('login');
+      } else {
+        alert('Registration failed');
+      }
+    } catch (err) {
+      console.error(err);
+      alert('Error connecting to server');
+    }
+  };
+
+  if (view === 'login') {
+    return (
+      <div className="form-container">
+        <h2>Login</h2>
+        <form onSubmit={handleLogin}>
+          <input name="email" type="email" placeholder="Email" required />
+          <input name="password" type="password" placeholder="Password" required />
+          <button type="submit">Login</button>
+        </form>
+        <p>Don't have an account? <button onClick={() => setView('register')}>Register</button></p>
+      </div>
+    );
+  }
+
+  if (view === 'register') {
+    return (
+      <div className="form-container">
+        <h2>Register</h2>
+        <form onSubmit={handleRegister}>
+          <input name="email" type="email" placeholder="Email" required />
+          <input name="password" type="password" placeholder="Password" required />
+          <button type="submit">Register</button>
+        </form>
+        <p>Already have an account? <button onClick={() => setView('login')}>Login</button></p>
+      </div>
+    );
+  }
+
+  if (view === 'index') {
+    return (
+      <div>
+        <h1>Welcome to TuristAPP</h1>
+        <p>You are logged in.</p>
+      </div>
+    );
+  }
+
+  return null;
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/front/public/app.js
+++ b/front/public/app.js
@@ -1,4 +1,4 @@
-const API_BASE = 'https://proyectodevopsbackend-evcnbwdbcrdyc0d8.canadacentral-01.azurewebsites.net';
+const API_BASE = window.API_BASE || 'https://proyectodevopsbackend-evcnbwdbcrdyc0d8.canadacentral-01.azurewebsites.net';
 
 function App() {
   const [view, setView] = React.useState('login');

--- a/front/public/index.html
+++ b/front/public/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>TuristAPP Front</title>
+  <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+  <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; padding: 20px; }
+    .form-container { max-width: 300px; margin: auto; }
+    input { display: block; width: 100%; margin-bottom: 10px; padding: 8px; }
+    button { padding: 8px 16px; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel" src="app.js"></script>
+</body>
+</html>

--- a/front/public/index.html
+++ b/front/public/index.html
@@ -17,6 +17,7 @@
 </head>
 <body>
   <div id="root"></div>
+  <script src="/config.js"></script>
   <script type="text/babel" src="app.js"></script>
 </body>
 </html>

--- a/front/server.js
+++ b/front/server.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const path = require('path');
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.static(path.join(__dirname, 'public')));
+
+app.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'index.html'));
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/front/server.js
+++ b/front/server.js
@@ -2,8 +2,14 @@ const express = require('express');
 const path = require('path');
 const app = express();
 const PORT = process.env.PORT || 3000;
+const API_BASE = process.env.API_BASE || 'https://proyectodevopsbackend-evcnbwdbcrdyc0d8.canadacentral-01.azurewebsites.net';
 
 app.use(express.static(path.join(__dirname, 'public')));
+
+app.get('/config.js', (req, res) => {
+  res.type('application/javascript');
+  res.send(`window.API_BASE = '${API_BASE}';`);
+});
 
 app.get('*', (req, res) => {
   res.sendFile(path.join(__dirname, 'public', 'index.html'));


### PR DESCRIPTION
## Summary
- add `front` directory with Express server
- implement a minimal React app using CDN
- provide login and registration forms that talk to the deployed backend
- document how to run the frontend

## Testing
- `npm test --silent` (no tests defined)


------
https://chatgpt.com/codex/tasks/task_e_684a2bc69ad48332834ca1d702f5d8ba